### PR TITLE
feat(EWM-504): corrupt storage after restoration

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -205,6 +205,7 @@
   "contactSupportCantCreateFile": "Can't create log file",
   "contactSupportCantFindEmailClient": "Can't find email client",
   "contactSupportCantFindEmailClientShare": "Share log file",
+  "contactSupportOpenQa": "Open QA",
   "browserCloseAll": "Close All",
   "browserDone": "Done",
   "browserSearchURL": "Search or enter URL",

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -205,6 +205,7 @@
   "contactSupportCantCreateFile": "Can't create log file",
   "contactSupportCantFindEmailClient": "Can't find email client",
   "contactSupportCantFindEmailClientShare": "Share log file",
+  "contactSupportOpenQa": "Open QA",
   "browserCloseAll": "Close All",
   "browserDone": "Done",
   "browserSearchURL": "Search or enter URL",

--- a/lib/app/service/storage_service/account_seed_storage_service.dart
+++ b/lib/app/service/storage_service/account_seed_storage_service.dart
@@ -1,6 +1,7 @@
 import 'package:app/app/service/service.dart';
 import 'package:encrypted_storage/encrypted_storage.dart';
 import 'package:injectable/injectable.dart';
+import 'package:logging/logging.dart';
 import 'package:nekoton_repository/nekoton_repository.dart';
 
 /// This is a wrapper-class above [EncryptedStorage] that provides methods
@@ -8,7 +9,41 @@ import 'package:nekoton_repository/nekoton_repository.dart';
 @singleton
 class NekotonStorageService extends NekotonStorageRepository
     implements AbstractStorageService {
-  NekotonStorageService(super.storage);
+  NekotonStorageService({
+    required EncryptedStorage storage,
+  })  : _storage = storage,
+        super(storage);
+
+  final EncryptedStorage _storage;
+
+  final _logger = Logger('NekotonStorageService');
+
+  @override
+  Future<void> init() async {
+    try {
+      return await super.init();
+    } catch (e, s) {
+      _logger.severe('Failed to init NekotonStorageRepository', e, s);
+
+      if (_isEcnryptionError(e, s)) {
+        // If the key is lost we could only clear the db
+        await _storage.clearAll();
+        return super.init();
+      }
+
+      Error.throwWithStackTrace(e, s);
+    }
+  }
+
+  bool _isEcnryptionError(Object e, StackTrace s) {
+    final errorString = e.toString();
+    final stackTraceString = s.toString();
+
+    return errorString.contains('PaddingException') ||
+        stackTraceString.contains('PKCS7Padding.padCount') ||
+        stackTraceString.contains('AES.decrypt') ||
+        stackTraceString.contains('Encrypter.decrypt');
+  }
 
   @override
   Future<void> clear() async {

--- a/lib/di/di.config.dart
+++ b/lib/di/di.config.dart
@@ -231,8 +231,8 @@ extension GetItInjectableX on _i174.GetIt {
         () => _i1008.UpdateStatusChecker(gh<_i728.VersionComparator>()));
     gh.singleton<_i116.PresetsConnectionService>(
         () => _i116.PresetsConnectionService(gh<_i418.PresetsConfigReader>()));
-    gh.singleton<_i747.NekotonStorageService>(
-        () => _i747.NekotonStorageService(gh<_i426.EncryptedStorage>()));
+    gh.singleton<_i747.NekotonStorageService>(() =>
+        _i747.NekotonStorageService(storage: gh<_i426.EncryptedStorage>()));
     gh.singleton<_i721.BrowserFaviconURLStorageService>(() =>
         _i721.BrowserFaviconURLStorageService(
             gh<_i792.GetStorage>(instanceName: 'browser_favicon_urls')));

--- a/lib/feature/contact_support/bloc/contact_support_bloc.dart
+++ b/lib/feature/contact_support/bloc/contact_support_bloc.dart
@@ -1,6 +1,5 @@
-// ignore_for_file: use_build_context_synchronously
+//iignore_for_file: use_build_context_synchronously
 
-import 'package:app/app/router/app_route.dart';
 import 'package:app/app/service/messenger/messenger.dart';
 import 'package:app/core/app_build_type.dart';
 import 'package:app/core/bloc/bloc_mixin.dart';
@@ -12,7 +11,6 @@ import 'package:app/runner.dart';
 import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 part 'contact_support_bloc.freezed.dart';
@@ -42,7 +40,6 @@ class ContactSupportBloc extends Bloc<ContactSupportEvent, ContactSupportState>
             emitSafe(state.copyWith(isBusy: false));
             inject<MessengerService>().show(
               Message.error(
-                context: context,
                 message: LocaleKeys.contactSupportCantCreateFile.tr(),
               ),
             );
@@ -56,7 +53,6 @@ class ContactSupportBloc extends Bloc<ContactSupportEvent, ContactSupportState>
               emitSafe(state.copyWith(isBusy: false));
               inject<MessengerService>().show(
                 Message.error(
-                  context: context,
                   message: LocaleKeys.contactSupportCantFindEmailClient.tr(),
                   actionText:
                       LocaleKeys.contactSupportCantFindEmailClientShare.tr(),

--- a/lib/feature/contact_support/bloc/contact_support_bloc.dart
+++ b/lib/feature/contact_support/bloc/contact_support_bloc.dart
@@ -25,7 +25,7 @@ class ContactSupportBloc extends Bloc<ContactSupportEvent, ContactSupportState>
       : super(
           ContactSupportState(
             isBusy: false,
-            isQaEnabled: currentAppBuildType == AppBuildType.development,
+            isQaEnabled: currentAppBuildType != AppBuildType.production,
           ),
         ) {
     on<ContactSupportEvent>((event, emit) async {

--- a/lib/feature/contact_support/bloc/contact_support_bloc.dart
+++ b/lib/feature/contact_support/bloc/contact_support_bloc.dart
@@ -1,13 +1,18 @@
 // ignore_for_file: use_build_context_synchronously
 
+import 'package:app/app/router/app_route.dart';
 import 'package:app/app/service/messenger/messenger.dart';
+import 'package:app/core/app_build_type.dart';
 import 'package:app/core/bloc/bloc_mixin.dart';
 import 'package:app/di/di.dart';
 import 'package:app/feature/contact_support/contact_support.dart';
+import 'package:app/feature/qa/view/qa_page.dart';
 import 'package:app/generated/generated.dart';
+import 'package:app/runner.dart';
 import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 part 'contact_support_bloc.freezed.dart';
@@ -19,17 +24,22 @@ part 'contact_support_state.dart';
 class ContactSupportBloc extends Bloc<ContactSupportEvent, ContactSupportState>
     with BlocBaseMixin {
   ContactSupportBloc(this.context)
-      : super(const ContactSupportState.initial()) {
+      : super(
+          ContactSupportState(
+            isBusy: false,
+            isQaEnabled: currentAppBuildType == AppBuildType.development,
+          ),
+        ) {
     on<ContactSupportEvent>((event, emit) async {
       await event.map(
         sendEmail: (event) async {
-          emitSafe(const ContactSupportState.busy());
+          emitSafe(state.copyWith(isBusy: true));
           String? logFilePath;
           try {
             logFilePath = await contactSupportCreateLogfile();
           } catch (e, s) {
             _log.severe(e, null, s);
-            emitSafe(const ContactSupportState.initial());
+            emitSafe(state.copyWith(isBusy: false));
             inject<MessengerService>().show(
               Message.error(
                 context: context,
@@ -43,7 +53,7 @@ class ContactSupportBloc extends Bloc<ContactSupportEvent, ContactSupportState>
               await contactSupportEmailSend(event.mode, logFilePath);
             } catch (e, s) {
               _log.severe(e, null, s);
-              emitSafe(const ContactSupportState.initial());
+              emitSafe(state.copyWith(isBusy: false));
               inject<MessengerService>().show(
                 Message.error(
                   context: context,
@@ -56,7 +66,10 @@ class ContactSupportBloc extends Bloc<ContactSupportEvent, ContactSupportState>
             }
           }
 
-          emitSafe(const ContactSupportState.initial());
+          emitSafe(state.copyWith(isBusy: false));
+        },
+        openQaScreen: (event) async {
+          await showQaSheet(context: context);
         },
       );
     });

--- a/lib/feature/contact_support/bloc/contact_support_bloc.freezed.dart
+++ b/lib/feature/contact_support/bloc/contact_support_bloc.freezed.dart
@@ -16,44 +16,43 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ContactSupportEvent {
-  ContactSupportMode get mode => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(ContactSupportMode mode) sendEmail,
+    required TResult Function() openQaScreen,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(ContactSupportMode mode)? sendEmail,
+    TResult? Function()? openQaScreen,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(ContactSupportMode mode)? sendEmail,
+    TResult Function()? openQaScreen,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_SendEmail value) sendEmail,
+    required TResult Function(_OpenQaScreen value) openQaScreen,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_SendEmail value)? sendEmail,
+    TResult? Function(_OpenQaScreen value)? openQaScreen,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_SendEmail value)? sendEmail,
+    TResult Function(_OpenQaScreen value)? openQaScreen,
     required TResult orElse(),
   }) =>
-      throw _privateConstructorUsedError;
-
-  /// Create a copy of ContactSupportEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $ContactSupportEventCopyWith<ContactSupportEvent> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -62,8 +61,6 @@ abstract class $ContactSupportEventCopyWith<$Res> {
   factory $ContactSupportEventCopyWith(
           ContactSupportEvent value, $Res Function(ContactSupportEvent) then) =
       _$ContactSupportEventCopyWithImpl<$Res, ContactSupportEvent>;
-  @useResult
-  $Res call({ContactSupportMode mode});
 }
 
 /// @nodoc
@@ -78,27 +75,13 @@ class _$ContactSupportEventCopyWithImpl<$Res, $Val extends ContactSupportEvent>
 
   /// Create a copy of ContactSupportEvent
   /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? mode = null,
-  }) {
-    return _then(_value.copyWith(
-      mode: null == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as ContactSupportMode,
-    ) as $Val);
-  }
 }
 
 /// @nodoc
-abstract class _$$SendEmailImplCopyWith<$Res>
-    implements $ContactSupportEventCopyWith<$Res> {
+abstract class _$$SendEmailImplCopyWith<$Res> {
   factory _$$SendEmailImplCopyWith(
           _$SendEmailImpl value, $Res Function(_$SendEmailImpl) then) =
       __$$SendEmailImplCopyWithImpl<$Res>;
-  @override
   @useResult
   $Res call({ContactSupportMode mode});
 }
@@ -163,6 +146,7 @@ class _$SendEmailImpl implements _SendEmail {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(ContactSupportMode mode) sendEmail,
+    required TResult Function() openQaScreen,
   }) {
     return sendEmail(mode);
   }
@@ -171,6 +155,7 @@ class _$SendEmailImpl implements _SendEmail {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(ContactSupportMode mode)? sendEmail,
+    TResult? Function()? openQaScreen,
   }) {
     return sendEmail?.call(mode);
   }
@@ -179,6 +164,7 @@ class _$SendEmailImpl implements _SendEmail {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(ContactSupportMode mode)? sendEmail,
+    TResult Function()? openQaScreen,
     required TResult orElse(),
   }) {
     if (sendEmail != null) {
@@ -191,6 +177,7 @@ class _$SendEmailImpl implements _SendEmail {
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_SendEmail value) sendEmail,
+    required TResult Function(_OpenQaScreen value) openQaScreen,
   }) {
     return sendEmail(this);
   }
@@ -199,6 +186,7 @@ class _$SendEmailImpl implements _SendEmail {
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_SendEmail value)? sendEmail,
+    TResult? Function(_OpenQaScreen value)? openQaScreen,
   }) {
     return sendEmail?.call(this);
   }
@@ -207,6 +195,7 @@ class _$SendEmailImpl implements _SendEmail {
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_SendEmail value)? sendEmail,
+    TResult Function(_OpenQaScreen value)? openQaScreen,
     required TResult orElse(),
   }) {
     if (sendEmail != null) {
@@ -219,56 +208,129 @@ class _$SendEmailImpl implements _SendEmail {
 abstract class _SendEmail implements ContactSupportEvent {
   const factory _SendEmail(final ContactSupportMode mode) = _$SendEmailImpl;
 
-  @override
   ContactSupportMode get mode;
 
   /// Create a copy of ContactSupportEvent
   /// with the given fields replaced by the non-null parameter values.
-  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SendEmailImplCopyWith<_$SendEmailImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-mixin _$ContactSupportState {
+abstract class _$$OpenQaScreenImplCopyWith<$Res> {
+  factory _$$OpenQaScreenImplCopyWith(
+          _$OpenQaScreenImpl value, $Res Function(_$OpenQaScreenImpl) then) =
+      __$$OpenQaScreenImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$OpenQaScreenImplCopyWithImpl<$Res>
+    extends _$ContactSupportEventCopyWithImpl<$Res, _$OpenQaScreenImpl>
+    implements _$$OpenQaScreenImplCopyWith<$Res> {
+  __$$OpenQaScreenImplCopyWithImpl(
+      _$OpenQaScreenImpl _value, $Res Function(_$OpenQaScreenImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ContactSupportEvent
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$OpenQaScreenImpl implements _OpenQaScreen {
+  const _$OpenQaScreenImpl();
+
+  @override
+  String toString() {
+    return 'ContactSupportEvent.openQaScreen()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$OpenQaScreenImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function() initial,
-    required TResult Function() busy,
-  }) =>
-      throw _privateConstructorUsedError;
+    required TResult Function(ContactSupportMode mode) sendEmail,
+    required TResult Function() openQaScreen,
+  }) {
+    return openQaScreen();
+  }
+
+  @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? initial,
-    TResult? Function()? busy,
-  }) =>
-      throw _privateConstructorUsedError;
+    TResult? Function(ContactSupportMode mode)? sendEmail,
+    TResult? Function()? openQaScreen,
+  }) {
+    return openQaScreen?.call();
+  }
+
+  @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? initial,
-    TResult Function()? busy,
+    TResult Function(ContactSupportMode mode)? sendEmail,
+    TResult Function()? openQaScreen,
     required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+  }) {
+    if (openQaScreen != null) {
+      return openQaScreen();
+    }
+    return orElse();
+  }
+
+  @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_Initial value) initial,
-    required TResult Function(_Busy value) busy,
-  }) =>
-      throw _privateConstructorUsedError;
+    required TResult Function(_SendEmail value) sendEmail,
+    required TResult Function(_OpenQaScreen value) openQaScreen,
+  }) {
+    return openQaScreen(this);
+  }
+
+  @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Initial value)? initial,
-    TResult? Function(_Busy value)? busy,
-  }) =>
-      throw _privateConstructorUsedError;
+    TResult? Function(_SendEmail value)? sendEmail,
+    TResult? Function(_OpenQaScreen value)? openQaScreen,
+  }) {
+    return openQaScreen?.call(this);
+  }
+
+  @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Initial value)? initial,
-    TResult Function(_Busy value)? busy,
+    TResult Function(_SendEmail value)? sendEmail,
+    TResult Function(_OpenQaScreen value)? openQaScreen,
     required TResult orElse(),
-  }) =>
+  }) {
+    if (openQaScreen != null) {
+      return openQaScreen(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _OpenQaScreen implements ContactSupportEvent {
+  const factory _OpenQaScreen() = _$OpenQaScreenImpl;
+}
+
+/// @nodoc
+mixin _$ContactSupportState {
+  bool get isBusy => throw _privateConstructorUsedError;
+  bool get isQaEnabled => throw _privateConstructorUsedError;
+
+  /// Create a copy of ContactSupportState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ContactSupportStateCopyWith<ContactSupportState> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -277,6 +339,8 @@ abstract class $ContactSupportStateCopyWith<$Res> {
   factory $ContactSupportStateCopyWith(
           ContactSupportState value, $Res Function(ContactSupportState) then) =
       _$ContactSupportStateCopyWithImpl<$Res, ContactSupportState>;
+  @useResult
+  $Res call({bool isBusy, bool isQaEnabled});
 }
 
 /// @nodoc
@@ -291,213 +355,118 @@ class _$ContactSupportStateCopyWithImpl<$Res, $Val extends ContactSupportState>
 
   /// Create a copy of ContactSupportState
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isBusy = null,
+    Object? isQaEnabled = null,
+  }) {
+    return _then(_value.copyWith(
+      isBusy: null == isBusy
+          ? _value.isBusy
+          : isBusy // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isQaEnabled: null == isQaEnabled
+          ? _value.isQaEnabled
+          : isQaEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
 }
 
 /// @nodoc
-abstract class _$$InitialImplCopyWith<$Res> {
-  factory _$$InitialImplCopyWith(
-          _$InitialImpl value, $Res Function(_$InitialImpl) then) =
-      __$$InitialImplCopyWithImpl<$Res>;
+abstract class _$$ContactSupportStateImplCopyWith<$Res>
+    implements $ContactSupportStateCopyWith<$Res> {
+  factory _$$ContactSupportStateImplCopyWith(_$ContactSupportStateImpl value,
+          $Res Function(_$ContactSupportStateImpl) then) =
+      __$$ContactSupportStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool isBusy, bool isQaEnabled});
 }
 
 /// @nodoc
-class __$$InitialImplCopyWithImpl<$Res>
-    extends _$ContactSupportStateCopyWithImpl<$Res, _$InitialImpl>
-    implements _$$InitialImplCopyWith<$Res> {
-  __$$InitialImplCopyWithImpl(
-      _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
+class __$$ContactSupportStateImplCopyWithImpl<$Res>
+    extends _$ContactSupportStateCopyWithImpl<$Res, _$ContactSupportStateImpl>
+    implements _$$ContactSupportStateImplCopyWith<$Res> {
+  __$$ContactSupportStateImplCopyWithImpl(_$ContactSupportStateImpl _value,
+      $Res Function(_$ContactSupportStateImpl) _then)
       : super(_value, _then);
 
   /// Create a copy of ContactSupportState
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isBusy = null,
+    Object? isQaEnabled = null,
+  }) {
+    return _then(_$ContactSupportStateImpl(
+      isBusy: null == isBusy
+          ? _value.isBusy
+          : isBusy // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isQaEnabled: null == isQaEnabled
+          ? _value.isQaEnabled
+          : isQaEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
 
 /// @nodoc
 
-class _$InitialImpl implements _Initial {
-  const _$InitialImpl();
+class _$ContactSupportStateImpl implements _ContactSupportState {
+  const _$ContactSupportStateImpl(
+      {required this.isBusy, required this.isQaEnabled});
+
+  @override
+  final bool isBusy;
+  @override
+  final bool isQaEnabled;
 
   @override
   String toString() {
-    return 'ContactSupportState.initial()';
+    return 'ContactSupportState(isBusy: $isBusy, isQaEnabled: $isQaEnabled)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$InitialImpl);
+        (other.runtimeType == runtimeType &&
+            other is _$ContactSupportStateImpl &&
+            (identical(other.isBusy, isBusy) || other.isBusy == isBusy) &&
+            (identical(other.isQaEnabled, isQaEnabled) ||
+                other.isQaEnabled == isQaEnabled));
   }
 
   @override
-  int get hashCode => runtimeType.hashCode;
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() initial,
-    required TResult Function() busy,
-  }) {
-    return initial();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? initial,
-    TResult? Function()? busy,
-  }) {
-    return initial?.call();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? initial,
-    TResult Function()? busy,
-    required TResult orElse(),
-  }) {
-    if (initial != null) {
-      return initial();
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Initial value) initial,
-    required TResult Function(_Busy value) busy,
-  }) {
-    return initial(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Initial value)? initial,
-    TResult? Function(_Busy value)? busy,
-  }) {
-    return initial?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Initial value)? initial,
-    TResult Function(_Busy value)? busy,
-    required TResult orElse(),
-  }) {
-    if (initial != null) {
-      return initial(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _Initial implements ContactSupportState {
-  const factory _Initial() = _$InitialImpl;
-}
-
-/// @nodoc
-abstract class _$$BusyImplCopyWith<$Res> {
-  factory _$$BusyImplCopyWith(
-          _$BusyImpl value, $Res Function(_$BusyImpl) then) =
-      __$$BusyImplCopyWithImpl<$Res>;
-}
-
-/// @nodoc
-class __$$BusyImplCopyWithImpl<$Res>
-    extends _$ContactSupportStateCopyWithImpl<$Res, _$BusyImpl>
-    implements _$$BusyImplCopyWith<$Res> {
-  __$$BusyImplCopyWithImpl(_$BusyImpl _value, $Res Function(_$BusyImpl) _then)
-      : super(_value, _then);
+  int get hashCode => Object.hash(runtimeType, isBusy, isQaEnabled);
 
   /// Create a copy of ContactSupportState
   /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ContactSupportStateImplCopyWith<_$ContactSupportStateImpl> get copyWith =>
+      __$$ContactSupportStateImplCopyWithImpl<_$ContactSupportStateImpl>(
+          this, _$identity);
 }
 
-/// @nodoc
-
-class _$BusyImpl implements _Busy {
-  const _$BusyImpl();
-
-  @override
-  String toString() {
-    return 'ContactSupportState.busy()';
-  }
+abstract class _ContactSupportState implements ContactSupportState {
+  const factory _ContactSupportState(
+      {required final bool isBusy,
+      required final bool isQaEnabled}) = _$ContactSupportStateImpl;
 
   @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$BusyImpl);
-  }
-
+  bool get isBusy;
   @override
-  int get hashCode => runtimeType.hashCode;
+  bool get isQaEnabled;
 
+  /// Create a copy of ContactSupportState
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() initial,
-    required TResult Function() busy,
-  }) {
-    return busy();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? initial,
-    TResult? Function()? busy,
-  }) {
-    return busy?.call();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? initial,
-    TResult Function()? busy,
-    required TResult orElse(),
-  }) {
-    if (busy != null) {
-      return busy();
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Initial value) initial,
-    required TResult Function(_Busy value) busy,
-  }) {
-    return busy(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Initial value)? initial,
-    TResult? Function(_Busy value)? busy,
-  }) {
-    return busy?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Initial value)? initial,
-    TResult Function(_Busy value)? busy,
-    required TResult orElse(),
-  }) {
-    if (busy != null) {
-      return busy(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _Busy implements ContactSupportState {
-  const factory _Busy() = _$BusyImpl;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ContactSupportStateImplCopyWith<_$ContactSupportStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/feature/contact_support/bloc/contact_support_event.dart
+++ b/lib/feature/contact_support/bloc/contact_support_event.dart
@@ -4,4 +4,5 @@ part of 'contact_support_bloc.dart';
 class ContactSupportEvent with _$ContactSupportEvent {
   const factory ContactSupportEvent.sendEmail(ContactSupportMode mode) =
       _SendEmail;
+  const factory ContactSupportEvent.openQaScreen() = _OpenQaScreen;
 }

--- a/lib/feature/contact_support/bloc/contact_support_state.dart
+++ b/lib/feature/contact_support/bloc/contact_support_state.dart
@@ -2,6 +2,8 @@ part of 'contact_support_bloc.dart';
 
 @freezed
 class ContactSupportState with _$ContactSupportState {
-  const factory ContactSupportState.initial() = _Initial;
-  const factory ContactSupportState.busy() = _Busy;
+  const factory ContactSupportState({
+    required bool isBusy,
+    required bool isQaEnabled,
+  }) = _ContactSupportState;
 }

--- a/lib/feature/contact_support/widgets/contact_support/contact_support_sheet.dart
+++ b/lib/feature/contact_support/widgets/contact_support/contact_support_sheet.dart
@@ -34,11 +34,9 @@ Future<void> showContactSupportSheet({
       create: ContactSupportBloc.new,
       child: BlocListener<ContactSupportBloc, ContactSupportState>(
         listener: (context, state) {
-          state.whenOrNull(
-            initial: () {
-              Navigator.of(context).pop();
-            },
-          );
+          if (!state.isBusy) {
+            Navigator.of(context).pop();
+          }
         },
         child: ContactSupportSheet(mode: mode),
       ),
@@ -67,17 +65,31 @@ class ContactSupportSheet extends StatelessWidget {
       builder: (context, state) {
         return Padding(
           padding: const EdgeInsets.only(bottom: DimensSizeV2.d24),
-          child: AccentButton(
-            buttonShape: ButtonShape.pill,
-            title: buttonText,
-            isLoading: state.when(initial: () => false, busy: () => true),
-            onPressed: () => {
-              context.read<ContactSupportBloc>().add(
-                    ContactSupportEvent.sendEmail(
-                      mode,
-                    ),
-                  ),
-            },
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AccentButton(
+                buttonShape: ButtonShape.pill,
+                title: buttonText,
+                isLoading: state.isBusy,
+                onPressed: () {
+                  context
+                      .read<ContactSupportBloc>()
+                      .add(ContactSupportEvent.sendEmail(mode));
+                },
+              ),
+              if (state.isQaEnabled) const SizedBox(height: DimensSizeV2.d16),
+              if (state.isQaEnabled)
+                AccentButton(
+                  buttonShape: ButtonShape.pill,
+                  title: LocaleKeys.contactSupportOpenQa.tr(),
+                  onPressed: () {
+                    context
+                        .read<ContactSupportBloc>()
+                        .add(const ContactSupportEvent.openQaScreen());
+                  },
+                ),
+            ],
           ),
         );
       },

--- a/lib/feature/qa/qa.dart
+++ b/lib/feature/qa/qa.dart
@@ -1,0 +1,1 @@
+export 'view/view.dart';

--- a/lib/feature/qa/view/qa_model.dart
+++ b/lib/feature/qa/view/qa_model.dart
@@ -1,0 +1,37 @@
+import 'package:elementary/elementary.dart';
+import 'package:encrypted_storage/encrypted_storage.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class QaModel extends ElementaryModel {
+  QaModel({
+    required EncryptedStorage storage,
+  }) : _storage = storage;
+
+  static const String _keyKey = 'cipher_storage_key';
+  static const String _ivKey = 'cipher_storage_iv';
+
+  final EncryptedStorage _storage;
+  final _fss = const FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+
+  Future<void> clearEncryptedDb() async {
+    await _storage.clearAll();
+  }
+
+  Future<void> clearEncryptedKeys() async {
+    final key = await readKey();
+    if (key != null) {
+      await _fss.delete(key: _keyKey);
+    }
+
+    final iv = await readIv();
+    if (iv != null) {
+      await _fss.delete(key: _ivKey);
+    }
+  }
+
+  Future<String?> readIv() => _fss.read(key: _ivKey);
+
+  Future<String?> readKey() => _fss.read(key: _keyKey);
+}

--- a/lib/feature/qa/view/qa_model.dart
+++ b/lib/feature/qa/view/qa_model.dart
@@ -1,3 +1,5 @@
+import 'package:app/app/service/messenger/message.dart';
+import 'package:app/app/service/messenger/service/messenger_service.dart';
 import 'package:elementary/elementary.dart';
 import 'package:encrypted_storage/encrypted_storage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -5,12 +7,16 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 class QaModel extends ElementaryModel {
   QaModel({
     required EncryptedStorage storage,
-  }) : _storage = storage;
+    required MessengerService messengerService,
+  })  : _storage = storage,
+        _messengerService = messengerService;
 
   static const String _keyKey = 'cipher_storage_key';
   static const String _ivKey = 'cipher_storage_iv';
 
   final EncryptedStorage _storage;
+  final MessengerService _messengerService;
+
   final _fss = const FlutterSecureStorage(
     aOptions: AndroidOptions(encryptedSharedPreferences: true),
   );
@@ -29,6 +35,12 @@ class QaModel extends ElementaryModel {
     if (iv != null) {
       await _fss.delete(key: _ivKey);
     }
+  }
+
+  void showSuccessMessage(String message) {
+    _messengerService.show(
+      Message.successful(message: message),
+    );
   }
 
   Future<String?> readIv() => _fss.read(key: _ivKey);

--- a/lib/feature/qa/view/qa_page.dart
+++ b/lib/feature/qa/view/qa_page.dart
@@ -1,0 +1,111 @@
+import 'package:app/feature/qa/view/qa_wm.dart';
+import 'package:elementary/elementary.dart';
+import 'package:elementary_helper/elementary_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:ui_components_lib/ui_components_lib.dart';
+import 'package:ui_components_lib/v2/widgets/buttons/accent_button.dart';
+import 'package:ui_components_lib/v2/widgets/buttons/button_shape.dart';
+
+Future<void> showQaSheet({
+  required BuildContext context,
+}) {
+  return showCommonBottomSheet(
+    context: context,
+    body: (_, __) => const QaSheet(),
+  );
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.subtitle,
+    required this.value,
+  });
+
+  final String subtitle;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.themeStyleV2;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '$subtitle:',
+          maxLines: 1,
+          style: theme.textStyles.labelSmall.copyWith(
+            color: theme.colors.content1,
+          ),
+        ),
+        const SizedBox(height: DimensSizeV2.d4),
+        Text(
+          value,
+          style: theme.textStyles.labelMedium,
+          maxLines: 1,
+        ),
+      ],
+    );
+  }
+}
+
+class QaSheet extends ElementaryWidget<QaWidgetModel> {
+  const QaSheet({
+    Key? key,
+    WidgetModelFactory wmFactory = defaultQaWidgetModelFactory,
+  }) : super(wmFactory, key: key);
+
+  @override
+  Widget build(QaWidgetModel wm) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: DimensSizeV2.d24),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: DimensSizeV2.d8,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: Text(
+                'QA functions',
+                style: wm.theme.textStyles.headingLarge,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: DimensSizeV2.d24),
+            StateNotifierBuilder<String>(
+              listenableState: wm.key,
+              builder: (context, keyValue) {
+                return _InfoRow(
+                  subtitle: 'Key',
+                  value: keyValue ?? 'Not set',
+                );
+              },
+            ),
+            StateNotifierBuilder<String>(
+              listenableState: wm.iv,
+              builder: (context, ivValue) {
+                return _InfoRow(
+                  subtitle: 'IV',
+                  value: ivValue ?? 'Not set',
+                );
+              },
+            ),
+            const SizedBox(height: DimensSizeV2.d8),
+            AccentButton(
+              buttonShape: ButtonShape.pill,
+              title: 'Drop DB',
+              onPressed: wm.clearEncryptedDb,
+            ),
+            AccentButton(
+              buttonShape: ButtonShape.pill,
+              title: 'Drop Keys',
+              onPressed: wm.clearEncryptedKeys,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/qa/view/qa_wm.dart
+++ b/lib/feature/qa/view/qa_wm.dart
@@ -1,5 +1,3 @@
-import 'package:app/app/service/messenger/message.dart';
-import 'package:app/app/service/messenger/service/messenger_service.dart';
 import 'package:app/core/wm/custom_wm.dart';
 import 'package:app/di/di.dart';
 import 'package:app/feature/qa/view/qa_model.dart';
@@ -12,17 +10,13 @@ import 'package:ui_components_lib/v2/theme_style_v2.dart';
 QaWidgetModel defaultQaWidgetModelFactory(BuildContext context) {
   final model = QaModel(
     storage: inject<EncryptedStorage>(),
+    messengerService: inject(),
   );
-  return QaWidgetModel(model, messengerService: inject());
+  return QaWidgetModel(model);
 }
 
 class QaWidgetModel extends CustomWidgetModel<QaSheet, QaModel> {
-  QaWidgetModel(
-    super.model, {
-    required MessengerService messengerService,
-  }) : _messengerService = messengerService;
-
-  final MessengerService _messengerService;
+  QaWidgetModel(super.model);
 
   late final _key = createNotifier('');
   late final _iv = createNotifier('');
@@ -42,15 +36,11 @@ class QaWidgetModel extends CustomWidgetModel<QaSheet, QaModel> {
 
   Future<void> clearEncryptedDb() async {
     await model.clearEncryptedDb();
-    _messengerService.show(
-      Message.successful(message: 'Db dropped'),
-    );
+    model.showSuccessMessage('Db dropped');
   }
 
   Future<void> clearEncryptedKeys() async {
     await model.clearEncryptedKeys();
-    _messengerService.show(
-      Message.successful(message: 'Keys dropped'),
-    );
+    model.showSuccessMessage('Keys dropped');
   }
 }

--- a/lib/feature/qa/view/qa_wm.dart
+++ b/lib/feature/qa/view/qa_wm.dart
@@ -1,0 +1,56 @@
+import 'package:app/app/service/messenger/message.dart';
+import 'package:app/app/service/messenger/service/messenger_service.dart';
+import 'package:app/core/wm/custom_wm.dart';
+import 'package:app/di/di.dart';
+import 'package:app/feature/qa/view/qa_model.dart';
+import 'package:app/feature/qa/view/qa_page.dart';
+import 'package:elementary_helper/elementary_helper.dart';
+import 'package:encrypted_storage/encrypted_storage.dart';
+import 'package:flutter/material.dart';
+import 'package:ui_components_lib/v2/theme_style_v2.dart';
+
+QaWidgetModel defaultQaWidgetModelFactory(BuildContext context) {
+  final model = QaModel(
+    storage: inject<EncryptedStorage>(),
+  );
+  return QaWidgetModel(model, messengerService: inject());
+}
+
+class QaWidgetModel extends CustomWidgetModel<QaSheet, QaModel> {
+  QaWidgetModel(
+    super.model, {
+    required MessengerService messengerService,
+  }) : _messengerService = messengerService;
+
+  final MessengerService _messengerService;
+
+  late final _key = createNotifier('');
+  late final _iv = createNotifier('');
+
+  ThemeStyleV2 get theme => context.themeStyleV2;
+
+  ListenableState<String> get iv => _iv;
+  ListenableState<String> get key => _key;
+
+  @override
+  Future<void> initWidgetModel() async {
+    _iv.accept(await model.readIv());
+    _key.accept(await model.readKey());
+
+    super.initWidgetModel();
+  }
+
+  Future<void> clearEncryptedDb() async {
+    await model.clearEncryptedDb();
+    _messengerService.show(
+      Message.successful(message: 'Db dropped'),
+    );
+  }
+
+  Future<void> clearEncryptedKeys() async {
+    await model.clearEncryptedKeys();
+    _messengerService.show(
+      Message.successful(message: 'Keys dropped'),
+    );
+  }
+}

--- a/lib/feature/qa/view/view.dart
+++ b/lib/feature/qa/view/view.dart
@@ -1,0 +1,4 @@
+export 'qa_model.dart';
+export 'qa_page.dart';
+export 'qa_wm.dart';
+

--- a/lib/feature/qa/view/view.dart
+++ b/lib/feature/qa/view/view.dart
@@ -1,4 +1,3 @@
 export 'qa_model.dart';
 export 'qa_page.dart';
 export 'qa_wm.dart';
-

--- a/lib/generated/locale_keys.g.dart
+++ b/lib/generated/locale_keys.g.dart
@@ -208,6 +208,7 @@ abstract class LocaleKeys {
       'contactSupportCantFindEmailClient';
   static const contactSupportCantFindEmailClientShare =
       'contactSupportCantFindEmailClientShare';
+  static const contactSupportOpenQa = 'contactSupportOpenQa';
   static const browserCloseAll = 'browserCloseAll';
   static const browserDone = 'browserDone';
   static const browserSearchURL = 'browserSearchURL';


### PR DESCRIPTION
## Description

Users were experiencing app crashes and initialization failures due to encryption errors, specifically "Invalid or corrupted pad block" exceptions. These errors occurred when the encryption keys used for secure storage were lost or corrupted, preventing the app from properly decrypting stored data. This would lead to repeated bootstrap failures with no recovery path, leaving users stuck in a crash loop with no way to reset or recover their application state.

Our guess that this case could reproduced with restore app from backup on ios

copilot:all

## Type of Change

- Added error handling for encryption issues in NekotonStorageService
- Created a new QA screen accessible from the Contact Support page in development builds
- Added functionality to clear encrypted database and keys

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
