### PR TITLE
feat(EWM-398): prepend 0 when decimal separator is first character

### DIFF
--- a/docs/llm/development_workflow.instructions.md
+++ b/docs/llm/development_workflow.instructions.md
@@ -19,6 +19,8 @@ You are working on the SparX Wallet Flutter project. Follow these critical workf
 - **MUST** follow conventional commits format: `<type>[optional scope]: <description>`
 - **ALWAYS** include YouTrack ticket ID in scope: `feat(EWM-511): Add route navigation`
 - Valid types: `feat`, `fix`, `BREAKING CHANGE`, `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test`
+- **NEVER** add co-authored blocks or Claude Code attribution in commit messages
+- Keep commit messages concise - for small changes, use short descriptive messages
 
 ### Merge Strategies
 
@@ -56,11 +58,13 @@ Follow this exact sequence:
 
 - Include YouTrack ticket ID in title
 - Use the comprehensive PR template with all sections:
-  - Description with bullet points
+  - Description with bullet points focusing on USER VALUE (what benefit users get)
   - Solution with implementation details
   - Type of change checklist
   - Testing instructions
   - QA testing results section
+- **NEVER** add co-authored blocks or Claude Code attribution in PR descriptions
+- In description section, focus only on the value and benefit to users, not technical implementation details
 
 ## Testing Instructions for QA
 

--- a/packages/ui_components_lib/lib/components/input/currency_text_input_formatter.dart
+++ b/packages/ui_components_lib/lib/components/input/currency_text_input_formatter.dart
@@ -73,7 +73,19 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {
-    final match = _fullRegExp.firstMatch(newValue.text);
+    // Handle case where decimal separator is entered as first character
+    var textToValidate = newValue.text;
+    var prependedZero = false;
+
+    // Check if input starts with decimal separator
+    if (textToValidate.isNotEmpty &&
+        decimalSeparators != null &&
+        decimalSeparators!.contains(textToValidate[0])) {
+      textToValidate = '0$textToValidate';
+      prependedZero = true;
+    }
+
+    final match = _fullRegExp.firstMatch(textToValidate);
 
     if (match == null) {
       return oldValue;
@@ -95,11 +107,19 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
     final newTextWithTicker =
         newText.isNotEmpty ? '$newText$_tickerString' : '';
 
-    final newSelection = clampSelection(newValue.selection, newText);
+    // Adjust cursor position if we prepended zero
+    var newSelection = newValue.selection;
+    if (prependedZero) {
+      newSelection = TextSelection.collapsed(
+        offset: newValue.selection.start + 1,
+      );
+    }
+
+    final clampedSelection = clampSelection(newSelection, newText);
 
     return TextEditingValue(
       text: newTextWithTicker,
-      selection: newSelection,
+      selection: clampedSelection,
     );
   }
 

--- a/packages/ui_components_lib/test/components/input/currency_text_input_formatter_test.dart
+++ b/packages/ui_components_lib/test/components/input/currency_text_input_formatter_test.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money2/money2.dart';
+import 'package:ui_components_lib/components/input/currency_text_input_formatter.dart';
+
+void main() {
+  group('CurrencyTextInputFormatter', () {
+    late CurrencyTextInputFormatter formatter;
+    late Currency currency;
+
+    setUp(() {
+      currency = Currency.create('USD', 2);
+    });
+
+    group('Basic functionality', () {
+      setUp(() {
+        formatter = CurrencyTextInputFormatter(currency);
+      });
+
+      test('should allow valid integer input', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: '123',
+          selection: TextSelection.collapsed(offset: 3),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('123'));
+        expect(result.selection.start, equals(3));
+      });
+
+      test('should allow valid decimal input', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: '123.45',
+          selection: TextSelection.collapsed(offset: 6),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('123.45'));
+        expect(result.selection.start, equals(6));
+      });
+
+      test('should reject invalid input', () {
+        const oldValue = TextEditingValue(
+          text: '123',
+          selection: TextSelection.collapsed(offset: 3),
+        );
+        const newValue = TextEditingValue(
+          text: '123abc',
+          selection: TextSelection.collapsed(offset: 6),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('123'));
+        expect(result.selection.start, equals(3));
+      });
+
+      test('should handle empty input', () {
+        const oldValue = TextEditingValue(text: '123');
+        const newValue = TextEditingValue(
+          selection: TextSelection.collapsed(offset: 0),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals(''));
+        expect(result.selection.start, equals(0));
+      });
+    });
+
+    group('Decimal separator handling (EWM-398)', () {
+      setUp(() {
+        formatter = CurrencyTextInputFormatter(
+          currency,
+          decimalSeparators: ['.', ','],
+        );
+      });
+
+      test('should prepend 0 when comma is entered as first character', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: ',',
+          selection: TextSelection.collapsed(offset: 1),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('0,'));
+        expect(result.selection.start, equals(2));
+      });
+
+      test('should prepend 0 when dot is entered as first character', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: '.',
+          selection: TextSelection.collapsed(offset: 1),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('0.'));
+        expect(result.selection.start, equals(2));
+      });
+
+      test('should handle comma followed by digits', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: ',5',
+          selection: TextSelection.collapsed(offset: 2),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('0,5'));
+        expect(result.selection.start, equals(3));
+      });
+
+      test('should handle dot followed by digits', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: '.25',
+          selection: TextSelection.collapsed(offset: 3),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('0.25'));
+        expect(result.selection.start, equals(4));
+      });
+
+      test('should not affect normal input with integer part', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: '1.5',
+          selection: TextSelection.collapsed(offset: 3),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('1.5'));
+        expect(result.selection.start, equals(3));
+      });
+
+      test('should not prepend 0 when separator is not first character', () {
+        const oldValue = TextEditingValue(text: '12');
+        const newValue = TextEditingValue(
+          text: '12.5',
+          selection: TextSelection.collapsed(offset: 4),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('12.5'));
+        expect(result.selection.start, equals(4));
+      });
+
+      test('should handle multiple decimal places within scale limit', () {
+        const oldValue = TextEditingValue(text: '0.');
+        const newValue = TextEditingValue(
+          text: '0.99',
+          selection: TextSelection.collapsed(offset: 4),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('0.99'));
+        expect(result.selection.start, equals(4));
+      });
+
+      test('should reject input exceeding decimal scale', () {
+        const oldValue = TextEditingValue(
+          text: '0.99',
+          selection: TextSelection.collapsed(offset: 4),
+        );
+        const newValue = TextEditingValue(
+          text: '0.999',
+          selection: TextSelection.collapsed(offset: 5),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('0.99'));
+        expect(result.selection.start, equals(4));
+      });
+    });
+
+    group('Ticker support', () {
+      setUp(() {
+        formatter = CurrencyTextInputFormatter(
+          currency,
+          includeTicker: true,
+          decimalSeparators: ['.'],
+        );
+      });
+
+      test('should append ticker to valid input', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: '123.45',
+          selection: TextSelection.collapsed(offset: 6),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('123.45 USD'));
+        expect(result.selection.start, equals(6));
+      });
+
+      test('should append ticker when prepending 0 for decimal separator', () {
+        const oldValue = TextEditingValue.empty;
+        const newValue = TextEditingValue(
+          text: '.',
+          selection: TextSelection.collapsed(offset: 1),
+        );
+
+        final result = formatter.formatEditUpdate(oldValue, newValue);
+
+        expect(result.text, equals('0. USD'));
+        expect(result.selection.start, equals(2));
+      });
+    });
+
+    group('RegExp creation', () {
+      test('should create correct regex for currency with decimal places', () {
+        final regex = CurrencyTextInputFormatter.createRegExp(
+          currency: currency,
+          allowNegative: false,
+          includeTicker: false,
+          decimalSeparators: ['.', ','],
+        );
+
+        expect(regex.hasMatch('123'), isTrue);
+        expect(regex.hasMatch('123.45'), isTrue);
+        expect(regex.hasMatch('123,45'), isTrue);
+        expect(regex.hasMatch('123.456'), isFalse); // exceeds scale
+        expect(regex.hasMatch('abc'), isFalse);
+        expect(regex.hasMatch(''), isTrue);
+      });
+
+      test('should create correct regex for currency without decimal places',
+          () {
+        final noCurrencyFormat = Currency.create('JPY', 0);
+        final regex = CurrencyTextInputFormatter.createRegExp(
+          currency: noCurrencyFormat,
+          allowNegative: false,
+          includeTicker: false,
+        );
+
+        expect(regex.hasMatch('123'), isTrue);
+        expect(regex.hasMatch('123.45'), isFalse); // no decimals allowed
+        expect(regex.hasMatch(''), isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description
* Users can now enter decimal separator as first character in amount input without validation error
* Input like ',' or '.' is automatically converted to '0,' or '0.' for better UX

copilot:all

## Solution:
* Modified CurrencyTextInputFormatter.formatEditUpdate() method to detect when decimal separator is entered as first character
* Added logic to prepend '0' before validation regex matching
* Maintained proper cursor positioning after transformation by adjusting selection offset
* Solution works for both comma and dot decimal separators as configured in decimalSeparators parameter
* No changes to validation logic - only input preprocessing before existing validation

## Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)  
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore