### PR TITLE
EWM-390: Rename button to 'Add existing account' in External accounts section

### DIFF
--- a/lib/feature/profile/key_detail/view/key_detail_view.dart
+++ b/lib/feature/profile/key_detail/view/key_detail_view.dart
@@ -153,7 +153,9 @@ class KeyDetailView extends StatelessWidget {
           child: PrimaryButton(
             buttonShape: ButtonShape.pill,
             postfixIcon: LucideIcons.plus,
-            title: LocaleKeys.addNewAccount.tr(),
+            title: tab == KeyDetailAccountsTab.external
+                ? LocaleKeys.addExistingAccount.tr()
+                : LocaleKeys.addNewAccount.tr(),
             onPressed: () {
               switch (tab) {
                 case KeyDetailAccountsTab.local:


### PR DESCRIPTION
## Description
- Renamed button from "Add new account" to "Add existing account" in the External accounts section
- Button now shows contextually appropriate text based on the active tab (Local vs External)

## Solution
- Updated `key_detail_view.dart` to conditionally display button text based on the current tab
- Used existing localization key `addExistingAccount` for External accounts tab
- Maintained existing `addNewAccount` text for Local accounts tab (My accounts)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing instructions
1. Navigate to: Manage seeds and accounts → seed → key
2. Switch to "External accounts" tab
3. Verify button shows "Add existing account"
4. Switch to "My accounts" tab  
5. Verify button shows "Add new account"
6. Test that both buttons function correctly and open appropriate sheets

## QA testing results
- [ ] Tested on iOS
- [ ] Tested on Android
- [ ] Functionality works as expected
- [ ] UI appears correctly
- [ ] No regressions found