### PR TITLE
EWM-373: Add sticky header for seed groups in account selector

### DIFF
--- a/lib/feature/wallet/widgets/select_account/select_account_widget.dart
+++ b/lib/feature/wallet/widgets/select_account/select_account_widget.dart
@@ -36,33 +36,32 @@ class SelectAccountWidget
           child: DoubleSourceBuilder(
             firstSource: wm.list,
             secondSource: wm.currentAccount,
-            builder: (_, list, currentAccount) {
-              return SingleChildScrollView(
+            builder: (context, list, currentAccount) {
+              if (list == null) return const SizedBox.shrink();
+
+              final slivers = <Widget>[];
+
+              for (var index = 0; index < list.length; index++) {
+                final data = list[index];
+                final shouldAutoExpand = data.hasCurrentAccount(currentAccount);
+
+                // Add each seed as a sticky section
+                slivers.add(
+                  _SeedItemSliverSection(
+                    data: data,
+                    shouldAutoExpand: shouldAutoExpand,
+                    currentAccount: currentAccount,
+                    onTapAccount: (item) => wm.onSelect(item),
+                    getBalanceEntity: wm.getBalanceEntity,
+                    scrollController: scrollController,
+                  ),
+                );
+              }
+
+              return CustomScrollView(
                 controller: scrollController,
                 physics: const ClampingScrollPhysics(),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: List.generate(
-                    list?.length ?? 0,
-                    (index) {
-                      final data = list![index];
-                      final isExpanded = data.hasCurrentAccount(currentAccount);
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: DimensSizeV2.d8),
-                        child: _SeedItem(
-                          key: ValueKey(data.name),
-                          data: data,
-                          isExpanded: isExpanded,
-                          isLedger: data.isLedger,
-                          currentAccount: currentAccount,
-                          onTapAccount: (item) => wm.onSelect(item),
-                          getBalanceEntity: wm.getBalanceEntity,
-                          scrollController: scrollController,
-                        ),
-                      );
-                    },
-                  ),
-                ),
+                slivers: slivers,
               );
             },
           ),
@@ -89,8 +88,8 @@ class SelectAccountWidget
   }
 }
 
-class _SeedItem extends StatefulWidget {
-  const _SeedItem({
+class _SeedItemStickyDelegate extends SliverPersistentHeaderDelegate {
+  const _SeedItemStickyDelegate({
     required this.data,
     required this.isExpanded,
     required this.isLedger,
@@ -98,7 +97,7 @@ class _SeedItem extends StatefulWidget {
     required this.onTapAccount,
     required this.getBalanceEntity,
     required this.scrollController,
-    super.key,
+    required this.onToggleExpand,
   });
 
   final SelectAccountData data;
@@ -108,63 +107,145 @@ class _SeedItem extends StatefulWidget {
   final Function(KeyAccount) onTapAccount;
   final ListenableState<Money?> Function(KeyAccount) getBalanceEntity;
   final ScrollController scrollController;
+  final VoidCallback onToggleExpand;
 
   @override
-  State<_SeedItem> createState() => _SeedItemState();
-}
-
-class _SeedItemState extends State<_SeedItem> {
-  late bool _isExpanded = widget.isExpanded;
-  late bool _isScrollToAccount = true;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
     final theme = context.themeStyleV2;
-    return GestureDetector(
-      onTap: _toggleExpand,
-      child: Container(
-        padding: EdgeInsets.only(
-          top: DimensSizeV2.d16,
-          bottom: _isExpanded ? 0 : DimensSize.d16,
-        ),
-        decoration: BoxDecoration(
-          color: theme.colors.background2,
-          borderRadius: BorderRadius.circular(DimensRadiusV2.radius12),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SeedPhraseItemWidget(
-              name: widget.data.name,
-              isExpanded: _isExpanded,
-              isLedger: widget.isLedger,
-            ),
-            if (_isExpanded) const SizedBox(height: DimensSizeV2.d16),
-            if (_isExpanded) const CommonDivider(),
-            AnimatedSize(
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeInOut,
-              child: _isExpanded
-                  ? PrivateKeyItemWidget(
-                      seedWithInfo: widget.data.privateKeys,
-                      currentAccount: widget.currentAccount,
-                      onTap: widget.onTapAccount,
-                      getBalanceEntity: widget.getBalanceEntity,
-                      scrollController: widget.scrollController,
-                      isScrollToAccount: _isScrollToAccount,
-                    )
-                  : const SizedBox.shrink(),
-            ),
-          ],
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colors.background2,
+        borderRadius: BorderRadius.circular(DimensRadiusV2.radius12),
+      ),
+      child: GestureDetector(
+        onTap: onToggleExpand,
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: DimensSizeV2.d16),
+          child: SeedPhraseItemWidget(
+            name: data.name,
+            isExpanded: isExpanded,
+            isLedger: isLedger,
+          ),
         ),
       ),
     );
   }
 
-  void _toggleExpand() {
-    if (!_isExpanded && _isScrollToAccount) {
-      _isScrollToAccount = false;
+  @override
+  double get maxExtent => 50;
+
+  @override
+  double get minExtent => 50;
+
+  @override
+  bool shouldRebuild(_SeedItemStickyDelegate oldDelegate) {
+    return data != oldDelegate.data ||
+        isExpanded != oldDelegate.isExpanded ||
+        currentAccount != oldDelegate.currentAccount ||
+        onToggleExpand != oldDelegate.onToggleExpand;
+  }
+}
+
+class _SeedItemSliverSection extends StatefulWidget {
+  const _SeedItemSliverSection({
+    required this.data,
+    required this.shouldAutoExpand,
+    required this.currentAccount,
+    required this.onTapAccount,
+    required this.getBalanceEntity,
+    required this.scrollController,
+  });
+
+  final SelectAccountData data;
+  final bool shouldAutoExpand;
+  final KeyAccount? currentAccount;
+  final Function(KeyAccount) onTapAccount;
+  final ListenableState<Money?> Function(KeyAccount) getBalanceEntity;
+  final ScrollController scrollController;
+
+  @override
+  State<_SeedItemSliverSection> createState() => _SeedItemSliverSectionState();
+}
+
+class _SeedItemSliverSectionState extends State<_SeedItemSliverSection> {
+  late bool _isExpanded;
+
+  @override
+  void initState() {
+    super.initState();
+    _isExpanded = widget.shouldAutoExpand;
+  }
+
+  @override
+  void didUpdateWidget(_SeedItemSliverSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.shouldAutoExpand && !_isExpanded) {
+      _isExpanded = true;
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverMainAxisGroup(
+      slivers: [
+        SliverPersistentHeader(
+          pinned: true,
+          delegate: _SeedItemStickyDelegate(
+            data: widget.data,
+            isExpanded: _isExpanded,
+            isLedger: widget.data.isLedger,
+            currentAccount: widget.currentAccount,
+            onTapAccount: widget.onTapAccount,
+            getBalanceEntity: widget.getBalanceEntity,
+            scrollController: widget.scrollController,
+            onToggleExpand: _toggleExpand,
+          ),
+        ),
+        if (_isExpanded)
+          SliverToBoxAdapter(
+            child: Container(
+              margin: const EdgeInsets.only(
+                bottom: DimensSizeV2.d8,
+                left: DimensSizeV2.d8,
+                right: DimensSizeV2.d8,
+              ),
+              decoration: BoxDecoration(
+                color: context.themeStyleV2.colors.background2,
+                borderRadius: const BorderRadius.only(
+                  bottomLeft: Radius.circular(DimensRadiusV2.radius12),
+                  bottomRight: Radius.circular(DimensRadiusV2.radius12),
+                ),
+              ),
+              child: Column(
+                children: [
+                  const CommonDivider(),
+                  PrivateKeyItemWidget(
+                    seedWithInfo: widget.data.privateKeys,
+                    currentAccount: widget.currentAccount,
+                    onTap: widget.onTapAccount,
+                    getBalanceEntity: widget.getBalanceEntity,
+                    scrollController: widget.scrollController,
+                    isScrollToAccount: widget.shouldAutoExpand,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        if (!_isExpanded)
+          const SliverToBoxAdapter(
+            child: SizedBox(
+              height: 8,
+            ),
+          ),
+      ],
+    );
+  }
+
+  void _toggleExpand() {
     setState(() {
       _isExpanded = !_isExpanded;
     });


### PR DESCRIPTION
## Description

- Enables users to always see which seed group they are viewing when scrolling through accounts
- Improves navigation efficiency in the account selection screen

## Solution

Refactored the `SelectAccountWidget` to use `CustomScrollView` with `SliverPersistentHeader` for each seed group. Each seed header remains pinned to the top while scrolling through its accounts.

Key changes:
- Replaced `SingleChildScrollView` with `CustomScrollView` using slivers
- Created `_SeedItemStickyDelegate` to handle the sticky header behavior
- Implemented `_SeedItemSliverSection` to manage each seed group as a sliver section
- Headers remain visible and interactive while scrolling

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactoring

## Testing Instructions

1. Navigate to the account selection screen
2. Create or have multiple seed phrases with multiple accounts
3. Scroll through the account list
4. Verify that seed headers stick to the top when scrolling
5. Verify that clicking on headers still expands/collapses account lists
6. Test with both expanded and collapsed states

## QA Testing Results

- [ ] All testing instructions have been followed
- [ ] Feature works as expected
- [ ] No regressions found
- [ ] Edge cases tested